### PR TITLE
Fix IN_EXCL_UNLINK only available >= Linux 2.6.38

### DIFF
--- a/common/sysutils.c
+++ b/common/sysutils.c
@@ -68,6 +68,9 @@
 #endif
 #ifdef HAVE_INOTIFY_INIT
 # include <sys/inotify.h>
+# ifndef IN_EXCL_UNLINK
+#  define IN_EXCL_UNLINK 0x04000000
+# endif
 #endif /*HAVE_INOTIFY_INIT*/
 #ifdef HAVE_NPTH
 # include <npth.h>


### PR DESCRIPTION
IN_EXCL_UNLINK is only offered by the kernel as of 2.6.38, failing the build on
older Linux installations.

Alternatively, inotify support could be disabled entirely on kernels not offering 
IN_EXCL_UNLINK.