### PR TITLE
Add more instruction when install GnuPG

### DIFF
--- a/README
+++ b/README
@@ -40,7 +40,7 @@
     libksba      (ftp://ftp.gnupg.org/gcrypt/libksba/)
     libassuan    (ftp://ftp.gnupg.org/gcrypt/libassuan/)
   
-  Downgrade may be required. For example, on Ubuntu 16.04, the latest version of libgcrypt will not work. In this case you will need to downgrade the library.
+  Downgrade may be required. For example, on Ubuntu 16.04, install libgcrypt version 1.8.1 of  will not work. In this case you will need to downgrade the library.
   
   You should get the latest versions of course, the GnuPG configure
   script complains if a version is not sufficient.

--- a/README
+++ b/README
@@ -40,8 +40,7 @@
     libksba      (ftp://ftp.gnupg.org/gcrypt/libksba/)
     libassuan    (ftp://ftp.gnupg.org/gcrypt/libassuan/)
   
-  Downgrade maybe required. For example, on Ubuntu 16.04 latest version of libgcrypt will not work. 
-  In that case we need downgrade the library.
+  Downgrade may be required. For example, on Ubuntu 16.04, the latest version of libgcrypt will not work. In this case you will need to downgrade the library.
   
   You should get the latest versions of course, the GnuPG configure
   script complains if a version is not sufficient.

--- a/README
+++ b/README
@@ -39,7 +39,10 @@
     libgcrypt    (ftp://ftp.gnupg.org/gcrypt/libgcrypt/)
     libksba      (ftp://ftp.gnupg.org/gcrypt/libksba/)
     libassuan    (ftp://ftp.gnupg.org/gcrypt/libassuan/)
-
+  
+  Downgrade maybe required. For example, on Ubuntu 16.04 latest version of libgcrypt will not work. 
+  In that case we need downgrade the library.
+  
   You should get the latest versions of course, the GnuPG configure
   script complains if a version is not sufficient.
 

--- a/README
+++ b/README
@@ -40,7 +40,7 @@
     libksba      (ftp://ftp.gnupg.org/gcrypt/libksba/)
     libassuan    (ftp://ftp.gnupg.org/gcrypt/libassuan/)
   
-  Downgrade may be required. For example, on Ubuntu 16.04, install libgcrypt version 1.8.1 of  will not work. In this case you will need to downgrade the library.
+  Downgrade may be required. For example, on Ubuntu 16.04, install libgcrypt version 1.8.1 will not work. In this case you will need to downgrade the library.
   
   You should get the latest versions of course, the GnuPG configure
   script complains if a version is not sufficient.


### PR DESCRIPTION
Add more instructions fix this error:  version GPG_ERROR_1.0 not defined in file libgpg-error.so.0
References: https://bugs.archlinux.org/task/48994