### PR TITLE
compile error @command {gpg}

### DIFF
--- a/doc/gpg-card.texi
+++ b/doc/gpg-card.texi
@@ -339,7 +339,7 @@ for the specific parameters of a key.  It is used by
 key to its protocol specific certificate format (X.509, OpenPGP, or
 SecureShell).  Below the keygrip the key reference along with the key
 usage capabilities are show.  Finally the algorithm is printed in the
-format used by @command {gpg}.  At that point no other information is
+format used by @command{gpg}.  At that point no other information is
 shown because for these new keys gpg won't be able to find matching
 certificates.
 


### PR DESCRIPTION
just @command {gpg}. to @command{gpg}. compile error.

Hi,
have a compile 'a' compile error at OSX, ok, not only this problem also many others, but this is one to run over without an error.



OFFTOPIC:
Is there anywhere a place to write/publish a build doc for OSX?
I have recovered many fixes to get a valid build. (🤦‍♀️ )

Always the same problem on many projects: We all have installed many Libs and Dips but forgot what we all have on, sometimes just: Brew update and Brew install or doctor and it works.

Examples: 

- MAGICK_FONT_PATH=/System/Library/Fonts

-  brew install fig2dev

- brew install imagemagick

- brew install gawk

aso...

Best started from installing Brew


