### PR TITLE
Remove -Werror from configure.ac

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1631,7 +1631,7 @@ if test "$GCC" = yes; then
         fi
 
         AC_MSG_CHECKING([if gcc supports -Wlogical-op])
-        CFLAGS="-Wlogical-op -Werror"
+        CFLAGS="-Wlogical-op"
         AC_COMPILE_IFELSE([AC_LANG_PROGRAM([],[])],_gcc_wopt=yes,_gcc_wopt=no)
         AC_MSG_RESULT($_gcc_wopt)
         if test x"$_gcc_wopt" = xyes ; then


### PR DESCRIPTION
This creates a dependency on specific compiler versions since
default warnings change from compiler to compiler