### PR TITLE
Simplify logic change from commit #8cad11d

### DIFF
--- a/scd/app-piv.c
+++ b/scd/app-piv.c
@@ -3646,8 +3646,8 @@ app_select_piv (app_t app)
   s = find_tlv (apt, aptlen, 0x4F, &n);
   /* Some cards (new Yubikey) return only the PIX, while others
    * (old Yubikey, PivApplet) return the RID+PIX. */
-  if (!s || !((n == 6 && !memcmp (s, piv_aid+5, 4))
-              || (n == 11 && !memcmp (s, piv_aid, 9))))
+  if (!s || ((n != 6 || memcmp (s, piv_aid+5, 4))
+              && (n != 11 || memcmp (s, piv_aid, 9))))
     {
       /* The PIX does not match.  */
       log_error ("piv: missing or invalid DO 0x4F in APT\n");


### PR DESCRIPTION
The [commit \#8cad11d13b15b0ef672545b06450dfbea1fef18e](https://github.com/gpg/gnupg/commit/8cad11d13b15b0ef672545b06450dfbea1fef18e#diff-63fc989c945ccc6c638383a75e0c85c7f0b8b86ca1c2c893f0f11369b52234ed) introduced an expression in positive logic encapsulated in a "`!( )`" into an expression in negative logic.  IMO the whole expression became hard to comprehend, thus really hard to check for correctness by a human reader, due to this change.
The whole expression before and after this PR is logically equivalent, but due to aforementioned point, I was unable to check if it is really equivalent WRT its implicit actions triggered (i.e., the `memcmp` calls).  While I had some doubts before, now I am sure the it calls `memcmp` when it should.
Hence simplify the logic expression by converting all sub-expressions back to negative logic (as before commit #8cad11d).