### PR TITLE
Fix typos intoduced by commit #5732e7a

### DIFF
--- a/doc/scdaemon.texi
+++ b/doc/scdaemon.texi
@@ -229,7 +229,7 @@ socket.
 @item --pcsc-shared
 @opindex pcsc-shared
 Use shared mode to access the card via PC/SC.  This is a somewhat
-dangerous option because Scdaemon assumes exclusivbe access to teh
+dangerous option because Scdaemon assumes exclusive access to the
 card and for example caches certain information from the card.  Use
 this option only if you know what you are doing.
 


### PR DESCRIPTION
Fix two typos introduced into [doc/scdeamon.texi](https://github.com/gpg/gnupg/blob/master/doc/scdaemon.texi) by [commit \#5732e7a](https://github.com/gpg/gnupg/commit/5732e7a8e97cebf8e850c472e644e2a9b040836f).