### PR TITLE
wks: Allow access to newly created dirs

### DIFF
--- a/tools/gpg-wks-server.c
+++ b/tools/gpg-wks-server.c
@@ -1443,7 +1443,7 @@ check_and_publish (server_ctx_t ctx, const char *address, const char *nonce)
     }
 
   /* Make sure it is world readable.  */
-  if (gnupg_chmod (fnewname, "-rwxr--r--"))
+  if (gnupg_chmod (fnewname, "-rw-r--r--"))
     log_error ("can't set permissions of '%s': %s\n",
                fnewname, gpg_strerror (gpg_err_code_from_syserror()));
 

--- a/tools/wks-util.c
+++ b/tools/wks-util.c
@@ -845,13 +845,13 @@ wks_compute_hu_fname (char **r_fname, const char *addrspec)
   fname = make_filename_try (opt.directory, domain, NULL);
   if (fname && gnupg_stat (fname, &sb)
       && gpg_err_code_from_syserror () == GPG_ERR_ENOENT)
-    if (!gnupg_mkdir (fname, "-rwxr--r--") && opt.verbose)
+    if (!gnupg_mkdir (fname, "-rwxr-xr-x") && opt.verbose)
       log_info ("directory '%s' created\n", fname);
   xfree (fname);
   fname = make_filename_try (opt.directory, domain, "hu", NULL);
   if (fname && gnupg_stat (fname, &sb)
       && gpg_err_code_from_syserror () == GPG_ERR_ENOENT)
-    if (!gnupg_mkdir (fname, "-rwxr--r--") && opt.verbose)
+    if (!gnupg_mkdir (fname, "-rwxr-xr-x") && opt.verbose)
       log_info ("directory '%s' created\n", fname);
   xfree (fname);
 


### PR DESCRIPTION
the `x` bit is required for the webserver to access files in these directories.

If no access was intended, `"-rwx------"` should be used instead.