### PR TITLE
Rename thread_init() function to thread_init_dirmngr() to avoid conflict on AIX

### DIFF
--- a/dirmngr/dirmngr.c
+++ b/dirmngr/dirmngr.c
@@ -991,7 +991,7 @@ my_ntbtls_log_handler (void *opaque, int level, const char *fmt, va_list argv)
 
 /* Helper for initialize_modules.  */
 static void
-thread_init (void)
+thread_init_dirmngr (void)
 {
   static int npth_initialized = 0;
 
@@ -1023,7 +1023,7 @@ thread_init (void)
 static void
 initialize_modules (void)
 {
-  thread_init ();
+  thread_init_dirmngr ();
   cert_cache_init (hkp_cacert_filenames);
   crl_cache_init ();
   ks_hkp_init ();


### PR DESCRIPTION
Hi All,

When building GnuPG on AIX, the build fails in the dirmngr component due to a naming conflict with the system-provided thread_init() function.

AIX has thread_init() declaration in /usr/include/sys/thread.h, which conflicts with the function defined in dirmngr.c.

```
/opt/freeware/bin/gcc -maix64 -O2 -DHAVE_CONFIG_H -I. -I..  -DLOCALEDIR=\"/opt/freeware/share/locale\" -DGNUPG_BINDIR="\"/opt/freeware/bin\"" -DGNUPG_LIBEXECDIR="\"/opt/freeware/libexec64\"" -DGNUPG_LIBDIR="\"/opt/freeware/lib/gnupg\"" -DGNUPG_DATADIR="\"/opt/freeware/share/gnupg\"" -DGNUPG_SYSCONFDIR="\"/opt/freeware/etc/gnupg\"" -DGNUPG_LOCALSTATEDIR="\"/opt/freeware/var\""        -I/opt/freeware/include -std=gnu99 -I/opt/freeware/include -I/opt/freeware/include -I/opt/freeware/include/libassuan2 -I/opt/freeware/include -I/opt/freeware/include  -I/opt/freeware/include -I/opt/freeware/include/p11-kit-1 -I/opt/freeware/include -Wall -Wno-format-zero-length -Wno-pointer-sign -Wpointer-arith -g -O2 -MT dirmngr.o -MD -MP -MF .deps/dirmngr.Tpo -c -o dirmngr.o dirmngr.c
dirmngr.c:980:1: error: conflicting types for 'thread_init'
  980 | thread_init (void)
      | ^~~~~~~~~~~
In file included from /usr/include/sys/ptrace.h:28,
                 from /usr/include/sys/proc.h:42,
                 from /usr/include/sys/pri.h:43,
                 from /usr/include/sys/sched.h:38,
                 from /usr/include/sched.h:51,
                 from /usr/include/pthread.h:63,
                 from /opt/freeware/include/npth.h:52,
                 from dirmngr.c:46:
/usr/include/sys/thread.h:1128:6: note: previous declaration of 'thread_init' was here
 1128 | void thread_init(unsigned long long, unsigned long long);
      |      ^~~~~~~~~~~
```

**Affected Files**

This naming conflict exists in:

`dirmngr/dirmngr.c`

**Proposed Fix**

Rename the function to something unambiguous, e.g.:

`thread_init_dirmngr`